### PR TITLE
Test postgresql versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ before_script:
   - ansible --version
 
 env:
-  - SCENARIO=default
-  - SCENARIO=centos
+  - SCENARIO=default PSQL_VERSION=9.5
+  - SCENARIO=default PSQL_VERSION=9.6
+  - SCENARIO=centos PSQL_VERSION=9.5
+  - SCENARIO=centos PSQL_VERSION=9.6
 
 script:
   - "molecule test -s $SCENARIO"

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -18,6 +18,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
+  env:
+    PSQL_VERSION: ${PSQL_VERSION:-9.6}
   playbooks:
     converge: ./../shared/playbook.yml
   lint:

--- a/molecule/centos/molecule.yml
+++ b/molecule/centos/molecule.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
   name: galaxy
+  enabled: False
 driver:
   name: docker
 lint:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,6 +18,8 @@ platforms:
     dockerfile: ./../shared/Dockerfile.j2
 provisioner:
   name: ansible
+  env:
+    PSQL_VERSION: ${PSQL_VERSION:-9.6}
   # options:
   #   vvv: true
   playbooks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,7 @@
 ---
 dependency:
   name: galaxy
+  enabled: False
 driver:
   name: docker
 lint:

--- a/molecule/shared/playbook.yml
+++ b/molecule/shared/playbook.yml
@@ -4,6 +4,7 @@
   roles:
     - role: ansible-postgresql
       vars:
+        postgresql_version: "{{ lookup('env', 'PSQL_VERSION') }}"
         postgresql_config: true
         postgresql_config_hba:
           - type: host

--- a/molecule/shared/tests/test_default.py
+++ b/molecule/shared/tests/test_default.py
@@ -10,9 +10,8 @@ def get_facts(host):
     return host.ansible("setup")["ansible_facts"]
 
 
-# We could take an environment variable here from a build matrix?
 def get_psql_version():
-    return '9.6'
+    return os.getenv('PSQL_VERSION', '9.6')
 
 
 def get_config_path(host, type):
@@ -59,3 +58,12 @@ def test_hba(host):
     hba = host.file(config_path)
     assert hba.contains('0.0.0.0/0')
     assert hba.contains('::/0')
+
+
+def test_service(host):
+    facts = get_facts(host)
+
+    if facts['ansible_os_family'] == 'Debian':
+        assert host.service('postgresql').is_running
+    else:
+        assert host.service('postgresql-' + get_psql_version()).is_running

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 # tasks file for ansible-postgresql
+- import_tasks: preflight.yml
+
 - include_tasks: set_facts.yml
 
 - include_tasks: debian.yml

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure postgresql_version is not empty
+  assert:
+    that: postgresql_version | default(false)
+    quiet: true
+
+- name: Ensure that we configure postgresql when we want replication
+  assert:
+    that: postgresql_config
+    quiet: true
+  when: postgresql_enable_replication


### PR DESCRIPTION
The main objective is to add a matrix with different versions of PostgreSQL to ensure the tests run against all of them. The RedHat/CentOS packages seem to be full of _fun_, so I gathered this would be good to have before the role is extended for 10 and 11.

In the process, I managed to "empty" `postgresql_version`, which is why I added `preflight.yml` with a few assertions. It checks if the version is set (an empty version installs something, but then the role fails since paths are off) and also the configuration values (as for replication you need to have need both _enabled_).

LBNL, I disabled galaxy in molecule (as the role has no other dependencies currently), hoping to win a couple seconds.